### PR TITLE
Multiple Streaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Streak
 
+## 2.1.0 (2021-09-09)
+
+`streak-mode` now supports multiple streaks and totally customizable streak
+messages.
+
+#### Added
+
+- `(defun streak-new ...)` to interactively create a new streak.
+- `(defcustom streak-formatters ...)` to set per-streak string formatting functions.
+
+#### Changed
+
+- The streak file data format is now JSON. The old format can still be read, but
+  will be overwritten the first time you make a change, say via `streak-new` or
+  `streak-reset`, etc.
+- `streak-reset`, `streak-increment`, and `streak-decrement` now perform auto-completion.
+- Hours are no longer shown on the first day.
+
+#### Removed
+
+- The `streak-hour-pattern` and `streak-day-pattern` are removed in favour of `streak-formatters`.
+
 ## 2.0.0 (2021-08-22)
 
 #### Added

--- a/README.org
+++ b/README.org
@@ -48,22 +48,23 @@ This should automatically pull =streak= from Melpa. Now make sure to run =doom s
 -u=. Then in your =config.el=:
 
 #+begin_src elisp
-(require 'streak)
-(streak-mode)
+(use-package! streak
+  :config
+  (streak-mode))
 #+end_src
 
-This will start =streak-mode= upon startup.
+This will start =streak-mode= when Doom opens.
 
 * Usage
 
-=streak-mode= will automatically initialize the "streak file" the first time it is
-ran. Once you've started a streak, it will increment (in the mode line)
-automatically day by day.
+=streak-mode= will automatically create the "streak file" the first time a streak
+is made with =streak-new=. Once you've started a streak, it will increment (in the
+mode line) automatically day by day.
 
 Otherwise, consider these functions for more manual control:
 
-+ =streak-reset=: Reset your streak, with "now" as the new starting point.
-+ =streak-increment=: Increase your streak by 24 hours worth.
++ =streak-reset=: Reset a streak, with "now" as the new starting point.
++ =streak-increment=: Increase a streak by 24 hours worth.
 + =streak-decrement=: The opposite of the above.
 + =streak-update=: Reread the streak file and manually update the mode line.
 
@@ -73,8 +74,25 @@ The following aspects of =streak= can be customized (all found under the =streak
 customization group):
 
 + ~streak-file~: A filepath to the "streak file" where your records are kept.
-+ ~streak-hour-pattern~: A format string (think ~printf~) for displaying your streak by hours. Only applies on the first day.
-+ ~streak-day-pattern~: A format string for displaying your streak in days.
++ ~streak-formatters~: An =alist= of functions to customize how each streak is
+  formatted. The key of each pair must be a string that matches a streak name
+  found in your streak file, while the value must be a function that accepts the
+  days of that streak and returns a string.
+
+ #+begin_src elisp
+(setq streak-formatters '(("study" . (lambda (days) (format "Study: %d Days" days)))
+                          ("running" . (lambda (days) (format "Run: %d Days" days)))))
+ #+end_src
+
+So a full Doom config would look like:
+
+#+begin_src elisp
+(use-package! streak
+  :config
+  (setq streak-formatters '(("study" . (lambda (days) (format "Study: %d Days" days)))
+                            ("running" . (lambda (days) (format "Run: %d Days" days)))))
+  (streak-mode))
+#+end_src
 
 * FAQ
 

--- a/README.org
+++ b/README.org
@@ -13,7 +13,10 @@ your success in your mode line!
   - [[#melpa][Melpa]]
   - [[#doom-emacs][Doom Emacs]]
 - [[#usage][Usage]]
+  - [[#your-first-streak][Your First Streak]]
+  - [[#manual-streak-tweaking][Manual Streak Tweaking]]
 - [[#customization][Customization]]
+  - [[#all-the-icons][=all-the-icons=]]
 - [[#faq][FAQ]]
   - [[#how-is-this-different-from-org-habit][How is this different from =org-habit=?]]
 
@@ -57,11 +60,25 @@ This will start =streak-mode= when Doom opens.
 
 * Usage
 
-=streak-mode= will automatically create the "streak file" the first time a streak
-is made with =streak-new=. Once you've started a streak, it will increment (in the
-mode line) automatically day by day.
+** Your First Streak
 
-Otherwise, consider these functions for more manual control:
+=streak-mode= stores your data in its "streak file". This file will be created
+automatically the first time a streak is made with =streak-new=:
+
+#+begin_example
+M-x streak-new
+#+end_example
+
+You'll be asked to name your streak. You can keep this simple (a single word)
+since this label won't appear as-is in your modeline. How the modeline actually
+appears can be fully customized by you (see below).
+
+Once you've started your streak, it will increment (in the mode line)
+automatically day by day.
+
+** Manual Streak Tweaking
+
+Consider these functions for manual control over the specific streak values:
 
 + =streak-reset=: Reset a streak, with "now" as the new starting point.
 + =streak-increment=: Increase a streak by 24 hours worth.
@@ -93,6 +110,10 @@ So a full Doom config would look like:
                             ("running" . (lambda (days) (format "Run: %d Days" days)))))
   (streak-mode))
 #+end_src
+
+** =all-the-icons=
+
+TODO (Feel free to PR a working setup!)
 
 * FAQ
 

--- a/streak.el
+++ b/streak.el
@@ -88,7 +88,7 @@ time `streak-mode' is used."
         ;; guarantee it's at the beginning of the buffer.
         (goto-char (point-min))
         (json-parse-buffer))
-    (json-parse-error (make-hash-table :test 'equal))))
+    (error (make-hash-table :test 'equal))))
 
 (defun streak--render-streaks (streaks)
   "Render each streak in STREAKS together into a single string."

--- a/streak.el
+++ b/streak.el
@@ -172,13 +172,16 @@ Returns the time that was set."
 
 ;;;###autoload
 (defun streak-increment ()
-  "Move the streak start back by 1 day, increasing the overall streak days."
+  "Move a streak start back by 1 day, increasing the overall streak days."
   (interactive)
-  (let* ((start (streak--current-int))
-         (seconds-per-day 86400)
-         (new (- start seconds-per-day)))
-    (streak--set new)
-    (setq streak--streak-message (streak--render new))))
+  (let ((streaks (streak--current-streaks)))
+    (if (not (hash-table-empty-p streaks))
+        (when-let* ((choice (completing-read "Streak to increment: " streaks))
+                    (seconds-per-day 86400)
+                    (new (- (gethash choice streaks) seconds-per-day)))
+          (puthash choice new streaks)
+          (streak--write-streaks streaks)
+          (streak-update)))))
 
 ;;;###autoload
 (defun streak-decrement ()

--- a/streak.el
+++ b/streak.el
@@ -185,13 +185,16 @@ Returns the time that was set."
 
 ;;;###autoload
 (defun streak-decrement ()
-  "Move the streak start up by 1 day, decreasing the overall streak days."
+  "Move a streak start up by 1 day, decreasing the overall streak days."
   (interactive)
-  (let* ((start (streak--current-int))
-         (seconds-per-day 86400)
-         (new (+ start seconds-per-day)))
-    (streak--set new)
-    (setq streak--streak-message (streak--render new))))
+  (let ((streaks (streak--current-streaks)))
+    (if (not (hash-table-empty-p streaks))
+        (when-let* ((choice (completing-read "Streak to decrement: " streaks))
+                    (seconds-per-day 86400)
+                    (new (+ (gethash choice streaks) seconds-per-day)))
+          (puthash choice new streaks)
+          (streak--write-streaks streaks)
+          (streak-update)))))
 
 ;;;###autoload
 (defun streak-update ()

--- a/streak.el
+++ b/streak.el
@@ -15,12 +15,14 @@
 ;; This file is not part of GNU Emacs.
 ;;
 ;;; Commentary:
-;; `streak-mode' is a minor mode for tracking some daily streak. Exercising?
+;; `streak-mode' is a minor mode for tracking daily streaks. Exercising?
 ;; Learning a language? Trying to quit a bad habit? Track your success in your
 ;; mode line!
 ;;
-;; If you've broken your streak, it can be reset with `streak-reset'. Don't
-;; worry, you'll do better next time!
+;; Start a new streak with `streak-new'. If you've broken a streak, it can be
+;; reset with `streak-reset'. Don't worry, you'll do better next time!
+;;
+;; See the Github README for configuration specifics.
 ;;
 ;;; Code:
 
@@ -52,8 +54,7 @@
 (defcustom streak-formatters nil
   "An alist of keys paired with functions to custom format streak values.
 
-Each function is passed the name of the streak and its current
-value in days, and must yield a string."
+Each function is passed the length of the streak in days, and must yield a string."
   :group 'streak
   :type '(alist :key-type string :value-type function))
 
@@ -98,7 +99,7 @@ time `streak-mode' is used."
                             (let* ((start (gethash key streaks))
                                    (fmt (cdr (assoc key streak-formatters)))
                                    (delta (/ (- now start) seconds-per-day)))
-                              (cond (fmt (funcall fmt key delta))
+                              (cond (fmt (funcall fmt delta))
                                     ((string= "legacy" key) (format "%d" delta))
                                     (t (format "%c:%d" (string-to-char key) delta)))))
                           (hash-table-keys streaks))))

--- a/streak.el
+++ b/streak.el
@@ -103,8 +103,18 @@ time `streak-mode' is used."
 
 (defun streak--render-streaks (streaks)
   "Render each streak in STREAKS together into a single string."
-  (let ((strings (mapcar (lambda (streak) (streak--render streak))
-                         (hash-table-values streaks))))
+  ;; TODO Here. Take the first char of each key and format it like n:22. Then as
+  ;; a next goal, accept special formatting strings from a defcustom that are
+  ;; unique per key.
+  (let* ((now (streak--seconds-since-unix-epoch))
+         (seconds-per-day 86400)
+         (strings (mapcar (lambda (key)
+                            (let* ((start (gethash key streaks))
+                                   (delta (/ (- now start) seconds-per-day)))
+                              (if (string= "legacy" key)
+                                  (format "%d" delta)
+                                (format "%c:%d" (string-to-char key) delta))))
+                          (hash-table-keys streaks))))
     (concat " " (string-join strings " ") " ")))
 
 ;; TODO Can be removed once we think nobody is on the old data format anymore.

--- a/streak.el
+++ b/streak.el
@@ -5,8 +5,8 @@
 ;; Author: Colin Woodbury <https://www.fosskers.ca>
 ;; Maintainer: Colin Woodbury <colin@fosskers.ca>
 ;; Created: June 18, 2021
-;; Modified: August 29, 2021
-;; Version: 2.0.0
+;; Modified: September 9, 2021
+;; Version: 3.0.0
 ;; Keywords: calendar
 ;; Homepage: https://github.com/fosskers/streak
 ;; Package-Requires: ((emacs "27.1"))
@@ -65,13 +65,6 @@ value in days, and must yield a string."
   "Read the streak file and render the current streaks."
   (streak--render-streaks (streak--current-streaks)))
 
-(defun streak--current-int ()
-  "Read the streak file for the current streak."
-  (if (not (file-exists-p streak-file))
-      (streak--init)
-    (when-let ((buffer (find-file-noselect streak-file)))
-      (string-to-number (streak--buffer-first-line buffer)))))
-
 (defun streak--current-streaks ()
   "Read the streak file and return a hashtable of the current streaks.
 In the event that no streak file existed, an empty hashtable is
@@ -111,21 +104,6 @@ time `streak-mode' is used."
                           (hash-table-keys streaks))))
     (concat " " (string-join strings " ") " ")))
 
-;; TODO Can be removed once we think nobody is on the old data format anymore.
-(defun streak--buffer-first-line (buffer)
-  "Yield the first line of a BUFFER as a string."
-  (with-current-buffer buffer
-    (goto-char (point-min))
-    (buffer-substring-no-properties (line-beginning-position) (line-end-position))))
-
-(defun streak--init ()
-  "Initialize the streak file but don't set the mode line.
-Returns the time that was set."
-  (let ((now (streak--seconds-since-unix-epoch)))
-    (message "Streak: Setting your streak start to the current time.")
-    (streak--set now)
-    now))
-
 ;;;###autoload
 (defun streak-new (name)
   "Given the NAME of a new streak to track, add it to the streak file."
@@ -157,18 +135,6 @@ Returns the time that was set."
           (puthash choice (streak--seconds-since-unix-epoch) streaks)
           (streak--write-streaks streaks)
           (streak-update)))))
-
-;; TODO This has to be altered to create an initial streak. But also it should
-;; account for the default streak names set by the user (if set), since we now
-;; have to care about JSON.
-(defun streak--set (seconds)
-  "Set the streak in the streak file, given SECONDS since the Unix epoch."
-  (when-let ((buffer (find-file-noselect streak-file))
-             (date (format-time-string "%Y-%m-%d %H:%M" seconds (current-time-zone))))
-    (with-current-buffer buffer
-      (goto-char (point-min))
-      (insert (format "%d ;; %s\n" seconds date))
-      (save-buffer))))
 
 ;;;###autoload
 (defun streak-increment ()

--- a/streak.el
+++ b/streak.el
@@ -85,7 +85,7 @@ time `streak-mode' is used."
           ;; TODO This legacy compat logic can be removed after a while, once
           ;; there's probably nobody left on the old format.
           ((integerp json) (let ((streaks (make-hash-table)))
-                             (puthash :legacy json streaks)
+                             (puthash "legacy" json streaks)
                              streaks))
           (t (error "Unexpected json parsed from streak file")))))
 
@@ -123,6 +123,22 @@ Returns the time that was set."
     (message "Streak: Setting your streak start to the current time.")
     (streak--set now)
     now))
+
+;;;###autoload
+(defun streak-new (name)
+  "Given the NAME of a new streak to track, add it to the streak file."
+  (interactive "sName of new streak: ")
+  (let ((streaks (streak--current-streaks))
+        (now (streak--seconds-since-unix-epoch)))
+    (if (gethash name streaks)
+        (message "A streak by that name already exists.")
+      (puthash name now streaks)
+      (let ((buffer (find-file-noselect streak-file))
+            (json (json-serialize streaks)))
+        (with-current-buffer buffer
+          (delete-region (point-min) (point-max))
+          (insert json)
+          (save-buffer))))))
 
 ;;;###autoload
 (defun streak-reset ()

--- a/streak.el
+++ b/streak.el
@@ -6,7 +6,7 @@
 ;; Maintainer: Colin Woodbury <colin@fosskers.ca>
 ;; Created: June 18, 2021
 ;; Modified: September 9, 2021
-;; Version: 3.0.0
+;; Version: 2.1.0
 ;; Keywords: calendar
 ;; Homepage: https://github.com/fosskers/streak
 ;; Package-Requires: ((emacs "27.1"))


### PR DESCRIPTION
This PR adds support for multiple streaks. The data storage format is now JSON, and I've included logic that will handle the legacy format upon first reading, and then overwrite it with the new.

This also introduces `streak-new`, an interactive function to easily add new streaks. `streak-reset` and friends have been given auto-completion.